### PR TITLE
Port autoware_localization_srvs

### DIFF
--- a/localization/util/autoware_localization_srvs/CMakeLists.txt
+++ b/localization/util/autoware_localization_srvs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(geometry_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/PoseWithCovarianceStamped.srv"
+  DEPENDENCIES geometry_msgs
 )
 
 ament_package()

--- a/localization/util/autoware_localization_srvs/CMakeLists.txt
+++ b/localization/util/autoware_localization_srvs/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+project(autoware_localization_srvs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/PoseWithCovarianceStamped.srv"
+)
+
+ament_package()

--- a/localization/util/autoware_localization_srvs/package.xml
+++ b/localization/util/autoware_localization_srvs/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_localization_srvs</name>
+  <version>0.1.0</version>
+  <description>The autoware_localization_srvs package</description>
+  <maintainer email="yamato.ando@gmail.com">Yamato Ando</maintainer>
+
+  <license>Apache 2</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv
+++ b/localization/util/autoware_localization_srvs/srv/PoseWithCovarianceStamped.srv
@@ -1,0 +1,3 @@
+geometry_msgs/PoseWithCovarianceStamped pose_with_cov
+---
+geometry_msgs/PoseWithCovarianceStamped pose_with_cov


### PR DESCRIPTION
* Tested the build with ROS2 Foxy by
  * following [this](https://docs.google.com/document/d/1eqkWCKHZfHcaY4uvs1eSrIBPU6AZCkyxJI3XoRU1WeU/edit) but entering an AutowareAuto ADE environment instead (Foxy `.aderc` taken from [here](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/merge_requests/637#note_424910484))
  * running `colcon build --packages-up-to autoware_localization_srvs` in the `ros2` branch of the AutowareArchitectureProposal repo (with this branch checked out in the `autoware/autoware.iv` sub-repo)